### PR TITLE
SLING-10441 : use dedicated 'discovery' thread pool for scheduler ins…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.scheduler</artifactId>
-            <version>2.4.0</version>
+            <version>2.5.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
@@ -21,7 +21,6 @@ package org.apache.sling.discovery.commons.providers.base;
 import java.util.Date;
 import java.util.concurrent.locks.Lock;
 
-import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.discovery.DiscoveryService;
 import org.apache.sling.discovery.TopologyView;

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
@@ -21,6 +21,7 @@ package org.apache.sling.discovery.commons.providers.base;
 import java.util.Date;
 import java.util.concurrent.locks.Lock;
 
+import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.discovery.DiscoveryService;
 import org.apache.sling.discovery.TopologyView;
@@ -123,6 +124,7 @@ class MinEventDelayHandler {
         final boolean triggered = runAfter(minEventDelaySecs /*seconds*/ , new Runnable() {
     
             public void run() {
+                assertCorrectThreadPool();
                 lock.lock();
                 try{
                     if (cancelCnt!=validCancelCnt) {
@@ -174,6 +176,13 @@ class MinEventDelayHandler {
         return triggered;
     }
     
+    private final void assertCorrectThreadPool() {
+        if (!Thread.currentThread().getName().contains("sling-discovery")) {
+            logger.warn("assertCorrectThreadPool : not running as part of 'discovery' thread pool."
+                    + " Check configuration and ensure 'discovery' is in 'allowedPoolNames' of 'org.apache.sling.commons.scheduler'");
+        }
+    }
+
     /**
      * run the runnable after the indicated number of seconds, once.
      * @return true if the scheduling of the runnable worked, false otherwise
@@ -187,8 +196,7 @@ class MinEventDelayHandler {
         logger.trace("runAfter: trying with scheduler.fireJob");
         final Date date = new Date(System.currentTimeMillis() + seconds * 1000);
         try {
-            theScheduler.fireJobAt(null, runnable, null, date);
-            return true;
+            return theScheduler.schedule(runnable, theScheduler.AT(date).threadPoolName("discovery"));
         } catch (Exception e) {
             logger.info("runAfter: could not schedule a job: "+e);
             return false;

--- a/src/test/java/org/apache/sling/discovery/commons/providers/base/DummyScheduler.java
+++ b/src/test/java/org/apache/sling/discovery/commons/providers/base/DummyScheduler.java
@@ -70,6 +70,12 @@ public class DummyScheduler implements Scheduler {
             this.date = date;
             return this;
         }
+
+        @Override
+        public ScheduleOptions threadPoolName(String name) {
+            this.name = name;
+            return this;
+        }
     }
 
     private boolean failMode;


### PR DESCRIPTION
…tead of relying on availability on default thread pool

Note that this is part 1/3 as all 3 discovery.commons/.base/.oak need to be updated