### PR TITLE
SLING-10489 : ignore partially started instances :

### DIFF
--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
@@ -77,7 +77,8 @@ class MinEventDelayHandler {
      * Asks the MinEventDelayHandler to handle the new view
      * and return true if the caller shouldn't worry about any follow-up action -
      * only if the method returns false should the caller do the usual 
-     * handleNewView action
+     * handleNewView action.
+     * This caller of this method must ensure to be in a lock.lock() block
      */
     boolean handlesNewView(BaseTopologyView newView) {
         if (isDelaying) {

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
@@ -95,8 +95,8 @@ class MinEventDelayHandler {
         }
 
         if (viewStateManager.equalsIgnoreSyncToken(newView)) {
-            logSilencer.infoOrDebug("handlesNewView-" + newView.getLocalClusterSyncTokenId(),
-                    "handlesNewView: equalsIgnoreSyncToken, hence no delaying applicable");
+            // this is a frequent case, hence only log.debug
+            logger.debug("handlesNewView: equalsIgnoreSyncToken, hence no delaying applicable");
             return false;
         }
         

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
@@ -25,6 +25,7 @@ import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.discovery.DiscoveryService;
 import org.apache.sling.discovery.TopologyView;
 import org.apache.sling.discovery.commons.providers.BaseTopologyView;
+import org.apache.sling.discovery.commons.providers.util.LogSilencer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,8 @@ class MinEventDelayHandler {
     
     private volatile int cancelCnt = 0;
     
+    private final LogSilencer logSilencer = new LogSilencer(logger);
+
     MinEventDelayHandler(ViewStateManagerImpl viewStateManager, Lock lock,
             DiscoveryService discoveryService, Scheduler scheduler,
             long minEventDelaySecs) {
@@ -80,17 +83,26 @@ class MinEventDelayHandler {
         if (isDelaying) {
             // already delaying, so we'll soon ask the DiscoveryServiceImpl for the
             // latest view and go ahead then
-            logger.info("handleNewView: already delaying, ignoring new view meanwhile");
+            logSilencer.infoOrDebug("handlesNewView-" + newView.getLocalClusterSyncTokenId(),
+                    "handleNewView: already delaying, ignoring new view meanwhile");
             return true;
         }
         
         if (!viewStateManager.hadPreviousView()) {
-            logger.info("handlesNewView: never had a previous view, hence no delaying applicable");
+            logSilencer.infoOrDebug("handlesNewView-" + newView.getLocalClusterSyncTokenId(),
+                    "handlesNewView: never had a previous view, hence no delaying applicable");
+            return false;
+        }
+
+        if (viewStateManager.equalsIgnoreSyncToken(newView)) {
+            logSilencer.infoOrDebug("handlesNewView-" + newView.getLocalClusterSyncTokenId(),
+                    "handlesNewView: equalsIgnoreSyncToken, hence no delaying applicable");
             return false;
         }
         
         if (viewStateManager.onlyDiffersInProperties(newView)) {
-            logger.info("handlesNewView: only properties differ, hence no delaying applicable");
+            logSilencer.infoOrDebug("handlesNewView-" + newView.getLocalClusterSyncTokenId(),
+                    "handlesNewView: only properties differ, hence no delaying applicable");
             return false;
         }
         
@@ -103,7 +115,8 @@ class MinEventDelayHandler {
         
         // thanks to force==true this will always return true
         if (!triggerAsyncDelaying(newView)) {
-            logger.info("handleNewView: could not trigger async delaying, sending new view now.");
+            logSilencer.infoOrDebug("handlesNewView-" + newView.getLocalClusterSyncTokenId(),
+                    "handleNewView: could not trigger async delaying, sending new view now.");
             viewStateManager.handleNewViewNonDelayed(newView);
         } else {
             // if triggering the async event was successful, then we should also
@@ -113,12 +126,13 @@ class MinEventDelayHandler {
             // even though there is the very unlikely possibility that the async-delay-thread
             // would compete - but even if it would, thanks to the lock.lock() that would be safe.
             // so: we're going to do a handleChanging here:
+            logger.info("handlesNewView: triggered async delaying, so now calling handleChanging..., new view = " + newView);
             viewStateManager.handleChanging();
         }
         return true;
     }
     
-    private boolean triggerAsyncDelaying(BaseTopologyView newView) {
+    private boolean triggerAsyncDelaying(final BaseTopologyView newView) {
         final int validCancelCnt = cancelCnt;
         final boolean triggered = runAfter(minEventDelaySecs /*seconds*/ , new Runnable() {
     
@@ -127,7 +141,8 @@ class MinEventDelayHandler {
                 lock.lock();
                 try{
                     if (cancelCnt!=validCancelCnt) {
-                        logger.info("asyncDelay.run: got cancelled (validCancelCnt="+validCancelCnt+", cancelCnt="+cancelCnt+"), quitting.");
+                        logSilencer.infoOrDebug("asyncDelay.run-cancel-" + newView.getLocalClusterSyncTokenId(),
+                                "asyncDelay.run: got cancelled (validCancelCnt="+validCancelCnt+", cancelCnt="+cancelCnt+"), quitting.");
                         return;
                     }
                     
@@ -144,10 +159,12 @@ class MinEventDelayHandler {
                     BaseTopologyView topology = (BaseTopologyView) t;
                     
                     if (topology.isCurrent()) {
-                        logger.info("asyncDelay.run: done delaying. got new view: "+ topology.toShortString());
+                        logSilencer.infoOrDebug("asyncDelay.run-done-" + newView.getLocalClusterSyncTokenId(),
+                                "asyncDelay.run: done delaying. got new view: "+ topology.toShortString());
                         viewStateManager.handleNewViewNonDelayed(topology);
                     } else {
-                        logger.info("asyncDelay.run: done delaying. new view (still/again) not current, delaying again");
+                        logSilencer.infoOrDebug("asyncDelay.run-done-" + newView.getLocalClusterSyncTokenId(),
+                                "asyncDelay.run: done delaying. new view (still/again) not current, delaying again");
                         triggerAsyncDelaying(topology);
                         // we're actually not interested in the result here
                         // if the async part failed, then we have to rely
@@ -168,7 +185,7 @@ class MinEventDelayHandler {
             }
         });
             
-        logger.info("triggerAsyncDelaying: asynch delaying of "+minEventDelaySecs+" triggered: "+triggered);
+        logSilencer.infoOrDebug("triggerAsyncDelaying", "triggerAsyncDelaying: asynch delaying of "+minEventDelaySecs+" triggered: "+triggered);
         if (triggered) {
             isDelaying = true;
         }

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/MinEventDelayHandler.java
@@ -126,7 +126,6 @@ class MinEventDelayHandler {
             // even though there is the very unlikely possibility that the async-delay-thread
             // would compete - but even if it would, thanks to the lock.lock() that would be safe.
             // so: we're going to do a handleChanging here:
-            logger.info("handlesNewView: triggered async delaying, so now calling handleChanging..., new view = " + newView);
             viewStateManager.handleChanging();
         }
         return true;

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
@@ -415,7 +415,7 @@ public class ViewStateManagerImpl implements ViewStateManager {
             throw new IllegalArgumentException("newView must not be null");
         }
         if (!newView.isCurrent()) {
-            logger.info("handleNewView: newView is not current - calling handleChanging, newView = " + newView);
+            logger.debug("handleNewView: newView is not current - calling handleChanging.");
             handleChanging();
             return;// false;
         }

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
@@ -468,7 +468,7 @@ public class ViewStateManagerImpl implements ViewStateManager {
                     return false;
                 }
                 if (previousView==null || !onlyDiffersInProperties(newView)) {
-                    logger.info("handleNewViewNonDelayed: implicitly triggering a handleChanging as we were not in changing state, new view = " + newView);
+                    logger.debug("handleNewViewNonDelayed: implicitly triggering a handleChanging as we were not in changing state");
                     handleChanging();
                     logger.debug("handleNewViewNonDelayed: implicitly triggering of a handleChanging done");
                 }

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
@@ -595,6 +595,9 @@ public class ViewStateManagerImpl implements ViewStateManager {
         }
     }
 
+    /**
+     * This caller of this method must ensure to be in a lock.lock() block
+     */
     protected boolean equalsIgnoreSyncToken(BaseTopologyView newView) {
         if (previousView==null) {
             return false;

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/ViewStateManagerImpl.java
@@ -596,6 +596,9 @@ public class ViewStateManagerImpl implements ViewStateManager {
     }
 
     /**
+     * Checks if the previouesView is equal to the newView, ignoring the
+     * syncToken (but only if the newView has partially started instances).
+     * <p/>
      * This caller of this method must ensure to be in a lock.lock() block
      */
     protected boolean equalsIgnoreSyncToken(BaseTopologyView newView) {
@@ -613,29 +616,7 @@ public class ViewStateManagerImpl implements ViewStateManager {
                 return previousView.equals(newView);
             }
         }
-        final Set<InstanceDescription> previousInstances = previousView.getInstances();
-        final Set<InstanceDescription> newInstances = newView.getInstances();
-        if (previousInstances.size() != newInstances.size()) {
-            return false;
-        }
-        for (Iterator<InstanceDescription> it = previousInstances.iterator(); it.hasNext();) {
-            InstanceDescription instanceDescription = (InstanceDescription) it
-                    .next();
-            boolean found = false;
-            for (Iterator<?> it2 = newInstances.iterator(); it2
-                    .hasNext();) {
-                InstanceDescription otherId = (InstanceDescription) it2
-                        .next();
-                if (instanceDescription.equals(otherId)) {
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                return false;
-            }
-        }
-        return true;
+        return previousView.getInstances().equals(newView.getInstances());
     }
 
     protected boolean onlyDiffersInProperties(BaseTopologyView newView) {

--- a/src/main/java/org/apache/sling/discovery/commons/providers/base/package-info.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/base/package-info.java
@@ -20,9 +20,9 @@
 /**
  * Provides commons implementations for providers of the Discovery API.
  *
- * @version 1.0.0
+ * @version 1.1.0
  */
-@Version("1.0.0")
+@Version("1.1.0")
 package org.apache.sling.discovery.commons.providers.base;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/discovery/commons/providers/spi/LocalClusterView.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/spi/LocalClusterView.java
@@ -18,11 +18,16 @@
  */
 package org.apache.sling.discovery.commons.providers.spi;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.sling.discovery.commons.providers.DefaultClusterView;
 
 public class LocalClusterView extends DefaultClusterView {
 
     private final String localClusterSyncTokenId;
+    private Set<Integer> partiallyStartedClusterNodeIds;
 
     public LocalClusterView(String id, String localClusterSyncTokenId) {
         super(id);
@@ -33,4 +38,21 @@ public class LocalClusterView extends DefaultClusterView {
         return localClusterSyncTokenId;
     }
 
+    public void setPartiallyStartedClusterNodeIds(Collection<Integer> clusterNodeIds) {
+        this.partiallyStartedClusterNodeIds = new HashSet<Integer>(clusterNodeIds);
+    }
+
+    public boolean isPartiallyStarted(Integer clusterNodeId) {
+        if (partiallyStartedClusterNodeIds == null || clusterNodeId == null) {
+            return false;
+        }
+        return partiallyStartedClusterNodeIds.contains(clusterNodeId);
+    }
+
+    public boolean hasPartiallyStartedInstances() {
+        if (partiallyStartedClusterNodeIds == null) {
+            return false;
+        }
+        return !partiallyStartedClusterNodeIds.isEmpty();
+    }
 }

--- a/src/main/java/org/apache/sling/discovery/commons/providers/spi/LocalClusterView.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/spi/LocalClusterView.java
@@ -19,6 +19,7 @@
 package org.apache.sling.discovery.commons.providers.spi;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,6 +37,10 @@ public class LocalClusterView extends DefaultClusterView {
     
     public String getLocalClusterSyncTokenId() {
         return localClusterSyncTokenId;
+    }
+
+    public Set<Integer> getPartiallyStartedClusterNodeIds() {
+        return Collections.unmodifiableSet(partiallyStartedClusterNodeIds);
     }
 
     public void setPartiallyStartedClusterNodeIds(Collection<Integer> clusterNodeIds) {

--- a/src/main/java/org/apache/sling/discovery/commons/providers/spi/base/AbstractServiceWithBackgroundCheck.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/spi/base/AbstractServiceWithBackgroundCheck.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.discovery.commons.providers.spi.base;
 
+import org.apache.sling.discovery.commons.providers.util.LogSilencer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,8 @@ public abstract class AbstractServiceWithBackgroundCheck {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected String slingId;
+
+    private final LogSilencer logSilencer = new LogSilencer(logger);
 
     /**
      * The BackgroundCheckRunnable implements the details of
@@ -83,9 +86,9 @@ public abstract class AbstractServiceWithBackgroundCheck {
                     if (timeoutMillis != -1 && 
                             (System.currentTimeMillis() > start + timeoutMillis)) {
                         if (callback == null) {
-                            logger.info("backgroundCheck.run: timeout hit (no callback to invoke)");
+                            logSilencer.infoOrDebug("backgroundCheck.run", "backgroundCheck.run: timeout hit (no callback to invoke)");
                         } else {
-                            logger.info("backgroundCheck.run: timeout hit, invoking callback.");
+                            logSilencer.infoOrDebug("backgroundCheck.run", "backgroundCheck.run: timeout hit, invoking callback.");
                             callback.run();
                         }
                         return;
@@ -131,7 +134,7 @@ public abstract class AbstractServiceWithBackgroundCheck {
 
         void cancel() {
             if (!done) {
-                logger.info("cancel: "+threadName);
+                logSilencer.infoOrDebug("cancel-" + threadName, "cancel: "+threadName);
             }
             cancelled = true;
         }
@@ -200,14 +203,15 @@ public abstract class AbstractServiceWithBackgroundCheck {
             // then we're not even going to start the background-thread
             // we're already done
             if (callback!=null) {
-                logger.info("backgroundCheck: already done, backgroundCheck successful, invoking callback");
+                logSilencer.infoOrDebug("backgroundCheck", "backgroundCheck: already done, backgroundCheck successful, invoking callback");
                 callback.run();
             } else {
-                logger.info("backgroundCheck: already done, backgroundCheck successful. no callback to invoke.");
+                logSilencer.infoOrDebug("backgroundCheck", "backgroundCheck: already done, backgroundCheck successful. no callback to invoke.");
             }
             return;
         }
-        logger.info("backgroundCheck: spawning background-thread for '"+threadName+"'");
+        logSilencer.infoOrDebug("backgroundCheck-" + threadName,
+                "backgroundCheck: spawning background-thread for '"+threadName+"'");
         backgroundCheckRunnable = new BackgroundCheckRunnable(callback, check, timeoutMillis, waitMillis, threadName);
         Thread th = new Thread(backgroundCheckRunnable);
         th.setName(threadName);

--- a/src/main/java/org/apache/sling/discovery/commons/providers/spi/package-info.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/spi/package-info.java
@@ -20,9 +20,9 @@
 /**
  * Provides an SPI for providers, used by discovery.commons.providers.impl
  *
- * @version 1.0.0
+ * @version 1.1.0
  */
-@Version("1.0.0")
+@Version("1.1.0")
 package org.apache.sling.discovery.commons.providers.spi;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/main/java/org/apache/sling/discovery/commons/providers/util/LogSilencer.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/util/LogSilencer.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.discovery.commons.providers.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+
+/**
+ * Helper class to help reduce log.info output. It will avoid repetitive
+ * log.info calls and instead log future occurrences to log.debug
+ */
+public class LogSilencer {
+
+    private static final long DEFAULT_AUTO_RESET_DELAY_MINUTES = 10;
+
+    private final Logger logger;
+
+    private final Object syncObj = new Object();
+
+    private final long autoResetDelayMillis;
+
+    private Map<String, String> lastMsgPerCategory;
+
+    private long autoResetTime = 0;
+
+    public LogSilencer(Logger logger, long autoResetDelaySeconds) {
+        this.logger = logger;
+        if (autoResetDelaySeconds > 0) {
+            autoResetDelayMillis = TimeUnit.MINUTES.toMillis(autoResetDelaySeconds);
+        } else {
+            autoResetDelayMillis = 0;
+        }
+    }
+
+    public LogSilencer(Logger logger) {
+        this(logger, DEFAULT_AUTO_RESET_DELAY_MINUTES);
+    }
+
+    public void infoOrDebug(String category, String msg) {
+        final boolean doLogInfo;
+        synchronized (syncObj) {
+            if (autoResetTime == 0 || System.currentTimeMillis() > autoResetTime) {
+                reset();
+            }
+            if (lastMsgPerCategory == null) {
+                lastMsgPerCategory = new HashMap<>();
+            }
+            final String localLastMsg = lastMsgPerCategory.get(category);
+            if (localLastMsg == null || !localLastMsg.equals(msg)) {
+                doLogInfo = true;
+                lastMsgPerCategory.put(category, msg);
+            } else {
+                doLogInfo = false;
+            }
+        }
+        if (doLogInfo) {
+            logger.info(msg + " (future identical logs go to debug)");
+        } else {
+            logger.debug(msg);
+        }
+    }
+
+    public void infoOrDebug(String msg) {
+        infoOrDebug(null, msg);
+    }
+
+    public void reset() {
+        synchronized (syncObj) {
+            lastMsgPerCategory = null;
+            if (autoResetDelayMillis == 0) {
+                autoResetTime = Long.MAX_VALUE;
+            } else {
+                autoResetTime = System.currentTimeMillis() + autoResetDelayMillis;
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/apache/sling/discovery/commons/providers/util/LogSilencer.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/util/LogSilencer.java
@@ -42,10 +42,10 @@ public class LogSilencer {
 
     private long autoResetTime = 0;
 
-    public LogSilencer(Logger logger, long autoResetDelaySeconds) {
+    public LogSilencer(Logger logger, long autoResetDelayMinutes) {
         this.logger = logger;
-        if (autoResetDelaySeconds > 0) {
-            autoResetDelayMillis = TimeUnit.MINUTES.toMillis(autoResetDelaySeconds);
+        if (autoResetDelayMinutes > 0) {
+            autoResetDelayMillis = TimeUnit.MINUTES.toMillis(autoResetDelayMinutes);
         } else {
             autoResetDelayMillis = 0;
         }

--- a/src/main/java/org/apache/sling/discovery/commons/providers/util/LogSilencer.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/util/LogSilencer.java
@@ -73,7 +73,7 @@ public class LogSilencer {
             }
         }
         if (doLogInfo) {
-            logger.info(msg + " (future identical logs go to debug)");
+            logger.info("{} {}", msg, "(future identical logs go to debug)");
         } else {
             logger.debug(msg);
         }

--- a/src/main/java/org/apache/sling/discovery/commons/providers/util/package-info.java
+++ b/src/main/java/org/apache/sling/discovery/commons/providers/util/package-info.java
@@ -20,9 +20,9 @@
 /**
  * Provides some static helpers for providers of the Discovery API.
  *
- * @version 1.0.0
+ * @version 1.1.0
  */
-@Version("1.0.0")
+@Version("1.1.0")
 package org.apache.sling.discovery.commons.providers.util;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/test/java/org/apache/sling/discovery/commons/providers/DummyTopologyView.java
+++ b/src/test/java/org/apache/sling/discovery/commons/providers/DummyTopologyView.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import org.apache.sling.discovery.ClusterView;
 import org.apache.sling.discovery.InstanceDescription;
 import org.apache.sling.discovery.InstanceFilter;
+import org.apache.sling.discovery.commons.providers.spi.LocalClusterView;
 
 public class DummyTopologyView extends BaseTopologyView {
 
@@ -199,7 +200,13 @@ public class DummyTopologyView extends BaseTopologyView {
             String clusterId = id.getClusterView().getId();
             DefaultClusterView cluster = clusters.get(clusterId);
             if (cluster==null) {
-                cluster = new DefaultClusterView(clusterId);
+                final ClusterView origCluster = id.getClusterView();
+                if (origCluster instanceof LocalClusterView) {
+                    final LocalClusterView localOrigCluster = (LocalClusterView) origCluster;
+                    cluster = new LocalClusterView(origCluster.getId(), localOrigCluster.getLocalClusterSyncTokenId());
+                } else {
+                    cluster = new DefaultClusterView(clusterId);
+                }
                 clusters.put(clusterId, cluster);
             }
             DefaultInstanceDescription clone = clone(cluster, id);

--- a/src/test/java/org/apache/sling/discovery/commons/providers/DummyTopologyView.java
+++ b/src/test/java/org/apache/sling/discovery/commons/providers/DummyTopologyView.java
@@ -203,7 +203,9 @@ public class DummyTopologyView extends BaseTopologyView {
                 final ClusterView origCluster = id.getClusterView();
                 if (origCluster instanceof LocalClusterView) {
                     final LocalClusterView localOrigCluster = (LocalClusterView) origCluster;
-                    cluster = new LocalClusterView(origCluster.getId(), localOrigCluster.getLocalClusterSyncTokenId());
+                    final LocalClusterView clonedCluster = new LocalClusterView(origCluster.getId(), localOrigCluster.getLocalClusterSyncTokenId());
+                    clonedCluster.setPartiallyStartedClusterNodeIds(localOrigCluster.getPartiallyStartedClusterNodeIds());
+                    cluster = clonedCluster;
                 } else {
                     cluster = new DefaultClusterView(clusterId);
                 }

--- a/src/test/java/org/apache/sling/discovery/commons/providers/spi/LocalClusterViewTest.java
+++ b/src/test/java/org/apache/sling/discovery/commons/providers/spi/LocalClusterViewTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.sling.discovery.commons.providers.spi;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LocalClusterViewTest {
+
+    private final LocalClusterView view = new LocalClusterView("id", "token");
+
+    @Test
+    public void partiallyStarted() {
+        assertFalse(view.hasPartiallyStartedInstances());
+        assertFalse(view.isPartiallyStarted(42));
+
+        view.setPartiallyStartedClusterNodeIds(Collections.<Integer>emptyList());
+        assertFalse(view.hasPartiallyStartedInstances());
+        assertFalse(view.isPartiallyStarted(42));
+
+        view.setPartiallyStartedClusterNodeIds(Arrays.asList(1, 2, 3));
+        assertTrue(view.hasPartiallyStartedInstances());
+        assertFalse(view.isPartiallyStarted(42));
+        assertTrue(view.isPartiallyStarted(1));
+        assertFalse(view.isPartiallyStarted(null));
+    }
+}


### PR DESCRIPTION
a. skipping activeIds in OakBacklogClusterSyncService if they are partially started
b. ignore syncToken for view change checks if there are partially started instances 
plus bonus c. LogSilencer introduced, which reduces log.info spam caused by discovery